### PR TITLE
Make subdomain optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ subdomain = golgafrincham
 Vous devez juste spécifier le nom de domaine ainsi que le sous-domaine que vous souhaitez utiliser en tant que dyndns.
 Le sous-domaine sera automatiquement créé s'il n'existe pas.
 
+Si aucun sous-domaine n'est spécifié, alors c'est le record racine du domaine qui est modifié.
+
 Pour tester le script:
 ```Bash
 python script.py


### PR DESCRIPTION
Hello,

J'ai fait quelques ajouts pour rendre le subDomain optionel, ce qui permet de changer le record racine et pas juste les records de sous-domaines.

Au passage j'ai voulu retirer les redondances dans les dictionaries, en créant tous les ensembles d'infos dont on a besoin au départ (`dataEdit` avec les infos à écrire dans le record, `dataFieldType` avec le champ fieldType approprié, `dataSubDomain` avec le sous domaine et qui peut donc être un dictionnaire vide), puis en les assemblant dans `dataGet`, `dataPost`, `dataPut`.

Testé et utilisé chez moi pour mettre à jour périodiquement un record A racine, sans sous-domaine.

Si ça t'intéresse :)